### PR TITLE
remove missing attributes

### DIFF
--- a/pyterprise/organization.py
+++ b/pyterprise/organization.py
@@ -17,14 +17,12 @@ class Organization(object):
         self.session_timeout = organization.session_timeout
         self.session_remember = organization.session_remember
         self.collaborator_auth_policy = organization.collaborator_auth_policy
-        self.enterprise_plan = organization.enterprise_plan
         self.plan_expired = organization.plan_expired
         self.cost_estimation_enabled = organization.cost_estimation_enabled
         self.permissions = organization.permissions
         self.fair_run_queuing_enabled = organization.fair_run_queuing_enabled
         self.saml_enabled = organization.saml_enabled
         self.two_factor_conformant = organization.two_factor_conformant
-        self.preview_request = organization.preview_request
 
     def __str__(self):
         return str(self.__dict__)


### PR DESCRIPTION
I was getting this error:

```
Traceback (most recent call last):
  File "amfam/ops/terraform/tfe_token_updater/main.py", line 19, in <module>
    for org in client.list_organizations():
  File "/home/ngrayson/.pyenv/versions/3.7.2/lib/python3.7/site-packages/pyterprise/client.py", line 32, in list_organizations
    api_handler=self._api_handler))
  File "/home/ngrayson/.pyenv/versions/3.7.2/lib/python3.7/site-packages/pyterprise/organization.py", line 20, in __init__
    self.enterprise_plan = organization.enterprise_plan
AttributeError: 'object_helper' object has no attribute 'enterprise_plan'
```

After a curl I found that the 2 removed attributes aren't in the org any longer